### PR TITLE
Support Cluster#run_once

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ cluster.run(:max_concurrency => 1) do |c|
 end
 ```
 
+### Run a command on only one host
+
+```
+cluster = Gopher::Cluster.new
+cluster << Gofer::Host.new('my.host.com', 'ubuntu', :keys => ['key.pem'], :output_prefix => "host1")
+cluster << Gofer::Host.new('other.host.com', 'ubuntu', :keys => ['key.pem'], :output_prefix => "host2")
+
+cluster.run_once("rake migrations") # Run migrations on only a single host
+```
+
+
 ## Testing
 
   * Ensure that your user can ssh as itself to localhost using the key in `~/.ssh/id_rsa`.

--- a/lib/gofer/cluster.rb
+++ b/lib/gofer/cluster.rb
@@ -29,6 +29,11 @@ module Gofer
       block.call(ClusterCommandRunner.new(hosts, concurrency))
     end
 
+    def run_once(cmd, opts={})
+      host = @hosts.first
+      host.run(cmd, opts)
+    end
+
     class ClusterCommandRunner
       def initialize(hosts, concurrency)
         @concurrency = concurrency

--- a/spec/gofer/integration_spec.rb
+++ b/spec/gofer/integration_spec.rb
@@ -271,5 +271,11 @@ describe Gofer do
 
       expect(res2[0].to_f).to be >= res1[1].to_f
     end
+
+    it "should respect run_once" do
+      res = @cluster.run_once("echo lols")
+
+      expect(res.stdout.chomp).to eq("lols")
+    end
   end
 end


### PR DESCRIPTION
`run_once`, for migrations etc.
