### PR TITLE
Proxy requests to all Host methods via a Cluster

### DIFF
--- a/lib/gofer/cluster.rb
+++ b/lib/gofer/cluster.rb
@@ -42,7 +42,7 @@ module Gofer
 
       # Spawn +concurrency+ worker threads, each of which pops work off the
       # +_in+ queue, and writes values to the +_out+ queue for syncronisation.
-      def run(cmd, opts={})
+      def threaded(meth, *args)
         _in = run_queue
         length = run_queue.length
         _out = Queue.new
@@ -52,7 +52,7 @@ module Gofer
             loop do
               host = _in.pop(false) rescue Thread.exit
 
-              results[host] = host.run(cmd, opts)
+              results[host] = host.send(meth, *args)
               _out << true
             end
           end
@@ -63,6 +63,12 @@ module Gofer
         end
 
         return results
+      end
+
+      [:run, :run_multiple, :exist?, :read, :directory?, :ls, :upload, :download, :write].each do |method|
+        self.send(:define_method, method) do |*args|
+          return threaded(method, *args)
+        end
       end
 
       def run_queue


### PR DESCRIPTION
This exposes all the methods on Host via the `ClusterCommandRunner`.

It's on the edge of too metaprogrammy and loses the arity checks, but on the upside it didn't involve too much copypasting
