### PR TITLE
Catch exceptions and still write to the queue

### DIFF
--- a/lib/gofer/cluster.rb
+++ b/lib/gofer/cluster.rb
@@ -94,10 +94,14 @@ module Gofer
       concurrency.times do
         Thread.new do
           loop do
-            host = _in.pop(false) rescue Thread.exit
+            begin
+              host = _in.pop(false) rescue Thread.exit
 
-            results[host] = host.send(meth, *args)
-            _out << true
+              results[host] = host.send(meth, *args)
+              _out << true
+            rescue
+              _out << false
+            end
           end
         end
       end


### PR DESCRIPTION
If you throw and exception in the thread pool you'll deadlock.

This patch ensures that it doesn't deadlock, although the onus is still on the user to check that `results.length` matches the size of the pool.

Once I work out how to deal with that condition sanely, I'll issue a followup patch.
