### PR TITLE
Support test cases when there is no global ruby

### DIFF
--- a/spec/gofer/cluster_spec.rb
+++ b/spec/gofer/cluster_spec.rb
@@ -15,7 +15,7 @@ describe Gofer::Cluster do
   after(:all) { clean_tmpdir }
 
   it "should run commands in parallel" do
-    results = @cluster.run("ruby -e 'puts Time.now.to_f; sleep 0.1; puts Time.now.to_f'")
+    results = @cluster.run("bash -l -c \"ruby -e 'puts Time.now.to_f; sleep 0.1; puts Time.now.to_f'\"")
 
     res1 = results[@host1].stdout.lines.to_a
     res2 = results[@host2].stdout.lines.to_a
@@ -25,7 +25,7 @@ describe Gofer::Cluster do
 
   it "should respect max_concurrency" do
     @cluster.max_concurrency = 1
-    results = @cluster.run("ruby -e 'puts Time.now.to_f; sleep 0.1; puts Time.now.to_f'")
+    results = @cluster.run("bash -l -c \"ruby -e 'puts Time.now.to_f; sleep 0.1; puts Time.now.to_f'\"")
 
     res1 = results[@host1].stdout.lines.to_a
     res2 = results[@host2].stdout.lines.to_a


### PR DESCRIPTION
Test cases fail when there is no globally installed ruby. More specifically, this affects machines running RVM or rbenv whose path is only available after running `.profile` or `.bash_profile`

This patch simply runs the two ruby commands using `bash -l` to cause bash to act as if the local user has logged in.
